### PR TITLE
add missing widgets variable to class

### DIFF
--- a/apps/dashboard/src/app/widgets/widgets.component.ts
+++ b/apps/dashboard/src/app/widgets/widgets.component.ts
@@ -21,6 +21,7 @@ const emptyWidget: Widget = {
   styleUrls: ['./widgets.component.scss'],
 })
 export class WidgetsComponent implements OnInit {
+  widgets  : Widget[];
   widgets$: Observable<Widget[]>;
   selectedWidget: Widget;
 


### PR DESCRIPTION
ERROR in apps/dashboard/src/app/widgets/widgets.component.ts:61:10

 `- error TS2551: Property 'widgets' does not exist on type 'WidgetsComponent'.`